### PR TITLE
chore: bump version to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## 2.1.2 - 2026-04-20
+## 2.2.2 - 2026-04-20
 ### Changed
 - added support of NC34, dropped NC30, NC31, and NC32
 - minimum required PHP raised from 8.1 to 8.2

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>Reddit integration</name>
 	<summary>Integration of Reddit social news aggregation service</summary>
 	<description><![CDATA[Reddit integration provides a dashboard widget displaying your recent subscribed news.]]></description>
-	<version>2.1.2</version>
+	<version>2.2.2</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Reddit</namespace>


### PR DESCRIPTION
Bumps the pending release version from 2.1.2 to 2.2.2 (and the matching CHANGELOG heading) to stay ahead of the orphan v2.2.1 tag that already exists on the repo.